### PR TITLE
take into account binary values

### DIFF
--- a/packages/node_modules/@enocean-js/eep-transcoder/src/eep-transcoder.js
+++ b/packages/node_modules/@enocean-js/eep-transcoder/src/eep-transcoder.js
@@ -261,6 +261,10 @@ function extractEnumValue (value, list) {
     if ('scale' in item && (parseInt(item.value) === value)) {
       return true
     }
+    var isBinary = item.value.startsWith('0b');
+    if (isBinary && parseInt(item.value.replace('0b', ''), 2) === value) {
+      return true
+    }
     if (parseInt(item.value) === value) {
       return true
     }


### PR DESCRIPTION
In this version of javascript, comparing a binary value written with 0b does not work. Indeed, the value should first be transformed from binary to decimal